### PR TITLE
Fix `podspec` to not include Info.plist

### DIFF
--- a/StringStylizer.podspec
+++ b/StringStylizer.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
 
-  s.source_files = 'StringStylizer/*'
+  s.source_files = 'StringStylizer/*.swift'
 end


### PR DESCRIPTION
Fixes building via CocoaPods in Xcode 10