### PR TITLE
Add support for Swift 4.2

### DIFF
--- a/StringStylizer.xcodeproj/project.pbxproj
+++ b/StringStylizer.xcodeproj/project.pbxproj
@@ -252,11 +252,11 @@
 					};
 					6E3F297F1CB2AB2600702DD3 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1000;
 					};
 					6E3F29891CB2AB2600702DD3 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -621,7 +621,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kazuhiro.hayashi.StringStylizer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -639,7 +639,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kazuhiro.hayashi.StringStylizer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -650,7 +650,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kazuhiro.hayashi.StringStylizerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -661,7 +661,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kazuhiro.hayashi.StringStylizerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/StringStylizer.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/StringStylizer.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/StringStylizer/StringStylizer.swift
+++ b/StringStylizer/StringStylizer.swift
@@ -61,25 +61,45 @@ open class StringStylizer<T: StringStylizerStatus>: ExpressibleByStringLiteral {
     public typealias UnicodeScalarLiteralType = String
     
     fileprivate var _attrString: NSAttributedString
+    #if swift(>=4.2)
+    fileprivate var _attributes = [NSAttributedString.Key: Any]()
+    #else
     fileprivate var _attributes = [NSAttributedStringKey: Any]()
+    #endif
     fileprivate var _range: CountableRange<UInt>
     
     // MARK:- Initializer
-    
-    init(string: String, range: CountableRange<UInt>? = nil, attributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey: Any]()) {
+
+    #if swift(>=4.2)
+    init(string: String, range: CountableRange<UInt>? = nil, attributes: [NSAttributedString.Key: Any] = [:]) {
         let attrString = NSAttributedString(string: string)
 
         _attrString = attrString
         _attributes = attributes
         _range = range ?? 0..<UInt(attrString.length)
     }
-    
-    init(attributedString: NSAttributedString, range: CountableRange<UInt>, attributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey: Any]()) {
+
+    init(attributedString: NSAttributedString, range: CountableRange<UInt>, attributes: [NSAttributedString.Key: Any] = [:]) {
         _attrString = attributedString
         _attributes = attributes
         _range = range
     }
-    
+    #else
+    init(string: String, range: CountableRange<UInt>? = nil, attributes: [NSAttributedStringKey: Any] = [:]) {
+        let attrString = NSAttributedString(string: string)
+
+        _attrString = attrString
+        _attributes = attributes
+        _range = range ?? 0..<UInt(attrString.length)
+    }
+
+    init(attributedString: NSAttributedString, range: CountableRange<UInt>, attributes: [NSAttributedStringKey: Any] = [:]) {
+        _attrString = attributedString
+        _attributes = attributes
+        _range = range
+    }
+    #endif
+
     public required init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
         _attrString = NSMutableAttributedString(string: value)
         _range = 0..<UInt(_attrString.string.characters.count)
@@ -309,7 +329,11 @@ open class StringStylizer<T: StringStylizerStatus>: ExpressibleByStringLiteral {
      - returns: StringStylizer<Styling>
      */
     open func underline(_ style: NSUnderlineStyle..., rgb: UInt? = nil, alpha: Double = 1) -> StringStylizer<Styling> {
+        #if swift(>=4.2)
+        let _style: [NSUnderlineStyle] = style.isEmpty ? [.single] : style
+        #else
         let _style: [NSUnderlineStyle] = style.isEmpty ? [.styleSingle] : style
+        #endif
         
         let value = _style.reduce(0) { (sum, elem) -> Int in
             return sum | elem.rawValue
@@ -385,7 +409,11 @@ open class StringStylizer<T: StringStylizerStatus>: ExpressibleByStringLiteral {
      - returns: StringStylizer<Styling>
      */
     open func strokeThrogh(_ style: NSUnderlineStyle..., rgb: UInt? = nil, alpha: Double = 1) -> StringStylizer<Styling>  {
+        #if swift(>=4.2)
+        let _style: [NSUnderlineStyle] = style.isEmpty ? [.single] : style
+        #else
         let _style: [NSUnderlineStyle] = style.isEmpty ? [.styleSingle] : style
+        #endif
         
         let value = _style.reduce(0) { (sum, elem) -> Int in
             return sum | elem.rawValue

--- a/StringStylizerTests/StringStylizerTests.swift
+++ b/StringStylizerTests/StringStylizerTests.swift
@@ -75,14 +75,23 @@ class StringStylizerTests: XCTestCase {
     }
     
     func testUnderline() {
+        #if swift(>=4.2)
+        let str = "StringStylizer".stylize().underline(.single).attr
+        let expected = NSAttributedString(string: "StringStylizer", attributes: [.underlineStyle:  NSUnderlineStyle.single.rawValue])
+        #else
         let str = "StringStylizer".stylize().underline(.styleSingle).attr
         let expected = NSAttributedString(string: "StringStylizer", attributes: [.underlineStyle:  NSUnderlineStyle.styleSingle.rawValue])
+        #endif
         XCTAssert(str.isEqual(to: expected), "has underline attributed")
     }
 
     func testUnderlineNoneParam() {
         let str = "StringStylizer".stylize().underline().attr
+        #if swift(>=4.2)
+        let expected = NSAttributedString(string: "StringStylizer", attributes: [.underlineStyle:  NSUnderlineStyle.single.rawValue])
+        #else
         let expected = NSAttributedString(string: "StringStylizer", attributes: [.underlineStyle:  NSUnderlineStyle.styleSingle.rawValue])
+        #endif
         XCTAssert(str.isEqual(to: expected), "has underline attributed")
     }
 
@@ -93,14 +102,23 @@ class StringStylizerTests: XCTestCase {
     }
     
     func testStrokeThroghParam() {
+        #if swift(>=4.2)
+        let str = "StringStylizer".stylize().strokeThrogh(.double).attr
+        let expected = NSAttributedString(string: "StringStylizer", attributes: [.strikethroughStyle:  NSUnderlineStyle.double.rawValue])
+        #else
         let str = "StringStylizer".stylize().strokeThrogh(.styleDouble).attr
         let expected = NSAttributedString(string: "StringStylizer", attributes: [.strikethroughStyle:  NSUnderlineStyle.styleDouble.rawValue])
+        #endif
         XCTAssert(str.isEqual(to: expected), "has strokeThrogh attributed")
     }
     
     func testStrokeThroghBlankParam() {
         let str = "StringStylizer".stylize().strokeThrogh().attr
+        #if swift(>=4.2)
+        let expected = NSAttributedString(string: "StringStylizer", attributes: [.strikethroughStyle:  NSUnderlineStyle.single.rawValue])
+        #else
         let expected = NSAttributedString(string: "StringStylizer", attributes: [.strikethroughStyle:  NSUnderlineStyle.styleSingle.rawValue])
+        #endif
         XCTAssert(str.isEqual(to: expected), "has strokeThrogh attributed")
     }
     


### PR DESCRIPTION
Swift 4.2 renames `NSAttributedStringKey` to `NSAttributedString.Key` and `NSUnderlineStyle` cases like `.styleSingle` to `.single`. This PR uses `#if swift(>4.2)` checks to simultaneously support both Swift 4.2 and lower versions.